### PR TITLE
Fix NullReferenceException in Server.Dispose

### DIFF
--- a/Nowin/Server.cs
+++ b/Nowin/Server.cs
@@ -84,7 +84,12 @@ namespace Nowin
             {
                 _connectionAllocationStrategy = new FinishingAllocationStrategy();
             }
-            ListenSocket.Close();
+
+            if (ListenSocket != null)
+            {
+                ListenSocket.Close();
+            }
+
             foreach (var block in _blocks)
             {
                 block.Stop();


### PR DESCRIPTION
If Server.Start is not invoked or throws an exception prior to assigning ListenSocket,
a NullReferenceException would be thrown from Dispose. This may hide the root
cause exception that prevented the server instance from starting up.