### PR TITLE
Made server creation call SetEndpoint

### DIFF
--- a/Nowin/OwinServerFactory.cs
+++ b/Nowin/OwinServerFactory.cs
@@ -52,7 +52,12 @@ namespace Nowin
                 var builder = ServerBuilder.New().SetOwinApp(app);
                 int port;
                 if (!int.TryParse(address.Get<string>("port"), out port)) throw new ArgumentException("port must be number from 0 to 65535");
-                builder.SetPort(port);
+                string host = address.Get<string>("host");
+                if (string.IsNullOrWhiteSpace(host)) throw new ArgumentException("host must be specified");
+                IPAddress ipAddress;
+                if (!IPAddress.TryParse(host,out ipAddress)) throw new ArgumentException("host must be a valid ip address");
+                var endpoint = new IPEndPoint(ipAddress, port);
+                builder.SetEndPoint(endpoint);
                 builder.SetOwinCapabilities(capabilities);
                 var certificate = address.Get<X509Certificate>("certificate");
                 if (certificate != null)

--- a/Nowin/OwinServerFactory.cs
+++ b/Nowin/OwinServerFactory.cs
@@ -53,17 +53,26 @@ namespace Nowin
                 int port;
                 if (!int.TryParse(address.Get<string>("port"), out port)) throw new ArgumentException("port must be number from 0 to 65535");
                 string host = address.Get<string>("host");
-                if (string.IsNullOrWhiteSpace(host)) throw new ArgumentException("host must be specified");
-                IPAddress ipAddress;
-                if (!IPAddress.TryParse(host,out ipAddress)) throw new ArgumentException("host must be a valid ip address");
-                var endpoint = new IPEndPoint(ipAddress, port);
-                builder.SetEndPoint(endpoint);
+                if (string.IsNullOrWhiteSpace(host))
+                {
+                    builder.SetPort(port);
+                }
+                else
+                {
+                    IPAddress ipAddress;
+                    if (!IPAddress.TryParse(host, out ipAddress))
+                    {
+                        throw new ArgumentException("host must be a valid ip address");
+                    }
+                    var endpoint = new IPEndPoint(ipAddress, port);
+                    builder.SetEndPoint(endpoint);
+                }
                 builder.SetOwinCapabilities(capabilities);
                 var certificate = address.Get<X509Certificate>("certificate");
                 if (certificate != null)
                     builder.SetCertificate(certificate);
                 servers.Add(builder.Build());
-                endpoints.Add(new IPEndPoint(IPAddress.Loopback,port));
+                endpoints.Add(new IPEndPoint(IPAddress.Loopback, port));
             }
 
             var disposer = new Disposer(servers.Cast<IDisposable>().ToArray());
@@ -78,7 +87,7 @@ namespace Nowin
                 {
                     var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
                     socket.Connect(ipEndPoint);
-                    socket.Close();                    
+                    socket.Close();
                 }
             }
             catch (Exception)

--- a/Nowin/OwinServerFactory.cs
+++ b/Nowin/OwinServerFactory.cs
@@ -56,6 +56,7 @@ namespace Nowin
                 if (string.IsNullOrWhiteSpace(host))
                 {
                     builder.SetPort(port);
+                    endpoints.Add(new IPEndPoint(IPAddress.Loopback, port));
                 }
                 else
                 {
@@ -66,13 +67,13 @@ namespace Nowin
                     }
                     var endpoint = new IPEndPoint(ipAddress, port);
                     builder.SetEndPoint(endpoint);
+                    endpoints.Add(endpoint);
                 }
                 builder.SetOwinCapabilities(capabilities);
                 var certificate = address.Get<X509Certificate>("certificate");
                 if (certificate != null)
                     builder.SetCertificate(certificate);
                 servers.Add(builder.Build());
-                endpoints.Add(new IPEndPoint(IPAddress.Loopback, port));
             }
 
             var disposer = new Disposer(servers.Cast<IDisposable>().ToArray());


### PR DESCRIPTION
I was using the sample on the README but I wanted to set it to be only 127.0.0.1. `netstat -a` showed the port was available on all ip addresses `0.0.0.0:1926` by default and even when I added a Url it was still on  `0.0.0.0:1926` and it was because only `SetPort` was being called.  With this change `netstat` shows that its listening on the IP specified

For example,

            var opts = new StartOptions()
            {
                ServerFactory = "Nowin",
                Urls = { "http://127.0.0.1:1926"}
            };
            using (WebApp.Start<Startup>(opts))
            {

                Console.WriteLine("Started on ");
                Console.ReadKey();
            }
               