### PR TITLE
Fix #44 / repair #43

### DIFF
--- a/Nowin/Transport2HttpHandler.cs
+++ b/Nowin/Transport2HttpHandler.cs
@@ -380,7 +380,11 @@ namespace Nowin
                         chs[used++] = (char)buffer[start - 1];
                         continue;
                     }
-                    cch = (char)(v1 * 16 + v2);
+
+                    chs[used++] = '%';
+                    chs[used++] = (char)buffer[start - 2];
+                    chs[used++] = (char)buffer[start - 1];
+                    continue;
                 }
                 else
                 {

--- a/NowinTests/NowinTestsBase.cs
+++ b/NowinTests/NowinTestsBase.cs
@@ -336,6 +336,7 @@ namespace NowinTests
         [InlineData("path?query", "/path", "query")]
         [InlineData("pathBase/path?query", "/pathBase/path", "query")]
         [InlineData("é?ù", "/é", "ù")]
+        [InlineData("/pathBase/path?query%20ge", "/pathBase/path", "query%20ge")]
         public void PathAndQueryParsing(string clientString, string expectedPath, string expectedQuery)
         {
             clientString = HttpClientAddress + clientString;

--- a/NowinTests/NowinTestsBase.cs
+++ b/NowinTests/NowinTestsBase.cs
@@ -335,8 +335,8 @@ namespace NowinTests
         [InlineData("", "/", "")]
         [InlineData("path?query", "/path", "query")]
         [InlineData("pathBase/path?query", "/pathBase/path", "query")]
-        [InlineData("é?ù", "/é", "ù")]
-        [InlineData("/pathBase/path?query%20ge", "/pathBase/path", "query%20ge")]
+        [InlineData("é?ù", "/%C3%A9", "%C3%B9")]
+        [InlineData("pathBase/path?query%20ge", "/pathBase/path", "query%20ge")]
         public void PathAndQueryParsing(string clientString, string expectedPath, string expectedQuery)
         {
             clientString = HttpClientAddress + clientString;


### PR DESCRIPTION
As I describe the problem in #44.
I think your test-cases made a wrong assumption too. In my opinion Nowin should not decode the query, but "just" make shure it arrives in the *right* form.