### PR TITLE
Don't write the server header if the server name is null, empty, or whitespace

### DIFF
--- a/Nowin/Transport2HttpHandler.cs
+++ b/Nowin/Transport2HttpHandler.cs
@@ -627,7 +627,7 @@ namespace Nowin
             {
                 HeaderAppend("Connection: close\r\n");
             }
-            if (!_serverNameOverwrite)
+            if (!string.IsNullOrWhiteSpace(_serverName) && !_serverNameOverwrite)
             {
                 HeaderAppend("Server: ");
                 HeaderAppend(_serverName);


### PR DESCRIPTION
What is says on the tin :)

I was setting the server header to null in the hope that it would suppress writing the header at all. It resulted in 500s because of NREs in `HeaderAppend()` which took a while to hunt down.

I think the user should have the ability to suppress this header and, personally, I'm happy with doing it by setting it to null.