### PR TITLE
Sending 'HTTP/1.1 200 OK' instead of 'HTTP/1.1 200'

### DIFF
--- a/Nowin/Transport2HttpHandler.cs
+++ b/Nowin/Transport2HttpHandler.cs
@@ -665,12 +665,19 @@ namespace Nowin
 
         void HeaderAppendHttpStatus(int status)
         {
-            // It always fits so skip buffer size check
-            var j = StartBufferOffset + ReceiveBufferSize + _responseHeaderPos;
-            _buffer[j++] = (byte)('0' + status / 100);
-            _buffer[j++] = (byte)('0' + status / 10 % 10);
-            _buffer[j] = (byte)('0' + status % 10);
-            _responseHeaderPos += 3;
+            if (status == 200)
+            {
+                HeaderAppend("200 OK");
+            }
+            else
+            {
+                // It always fits so skip buffer size check
+                var j = StartBufferOffset + ReceiveBufferSize + _responseHeaderPos;
+                _buffer[j++] = (byte) ('0' + status/100);
+                _buffer[j++] = (byte) ('0' + status/10%10);
+                _buffer[j] = (byte) ('0' + status%10);
+                _responseHeaderPos += 3;
+            }
         }
 
         void HeaderAppendCrLf()


### PR DESCRIPTION
I have device that requires 'HTTP/1.1 200 OK', 'HTTP/1.1 200' is not accepted.