### PR TITLE
Handle failed SSL authenticateasserver, fix IPv6 local address check

### DIFF
--- a/Nowin/IpIsLocalChecker.cs
+++ b/Nowin/IpIsLocalChecker.cs
@@ -32,7 +32,20 @@ namespace Nowin
 
         public bool IsLocal(IPAddress address)
         {
-            return _dict.ContainsKey(address);
+            if (_dict.ContainsKey(address))
+                return true;
+
+            if (IPAddress.IsLoopback(address))
+                return true;
+
+            if (address.IsIPv4MappedToIPv6)
+            {
+                var ip4 = address.MapToIPv4();
+                if (_dict.ContainsKey(ip4))
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/NowinTests/NowinTestsBase.cs
+++ b/NowinTests/NowinTestsBase.cs
@@ -419,11 +419,9 @@ namespace NowinTests
                     Assert.True(env.TryGetValue("server.IsLocal", out ignored));
                     Assert.Equal(true, env["server.IsLocal"]);
 
+                    // Don't check for actual IP address as it might be IPv6 local address
                     Assert.True(env.TryGetValue("server.RemoteIpAddress", out ignored));
-                    Assert.Equal("127.0.0.1", env["server.RemoteIpAddress"]);
-
                     Assert.True(env.TryGetValue("server.LocalIpAddress", out ignored));
-                    Assert.Equal("127.0.0.1", env["server.LocalIpAddress"]);
 
                     Assert.True(env.TryGetValue("server.RemotePort", out ignored));
                     Assert.True(env.TryGetValue("server.LocalPort", out ignored));


### PR DESCRIPTION
SSL: Authenticate continuation should complete only if the actual authenticate task completes. This prevents double disconnect coming when AuthenticateAsServerAsync fails.

Fix local IP address check to take into account IPv6 loopback addresses.