### PR TITLE
Fixed race condition in OwinHandler.cs

### DIFF
--- a/Nowin/OwinHandler.cs
+++ b/Nowin/OwinHandler.cs
@@ -358,7 +358,7 @@ namespace Nowin
             if (!success)
             {
                 _webSocketReceiveState = WebSocketReceiveState.Close;
-                _webSocketReceiveTcs?.SetCanceled();
+                _webSocketReceiveTcs?.TrySetCanceled();
                 _webSocketTcsReceivedClose?.TrySetResult(null);
                 return;
             }
@@ -427,7 +427,7 @@ namespace Nowin
             var tcs = new TaskCompletionSource<WebSocketReceiveTuple>();
             if (_webSocketReceiveState == WebSocketReceiveState.Close || _webSocketReceiveState == WebSocketReceiveState.Closing)
             {
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             }
             _webSocketReceiveTcs = tcs;


### PR DESCRIPTION
It seems to be a race condition in websocket handling. This fix just uses TrySetCanceled() instead of SetCanceled().

UnhandledException System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.\n  at System.Threading.Tasks.TaskCompletionSource`1[TResult].SetCanceled () [0x00015] in <94fd79a3b7144c54b4cb162b50fc7761>:0 \n  at Nowin.OwinHandler.FinishReceiveData (System.Boolean success) [0x0001d] in <6ac31060d0b54aa987e5b546abb289cb>:0 \n  at Nowin.Transport2HttpHandler.FinishReceive (System.Byte[] buffer, System.Int32 offset, System.Int32 length) [0x00066] in <6ac31060d0b54aa987e5b546abb289cb>:0 \n  at Nowin.SaeaLayerCallback.ProcessReceive () [0x00067] in <6ac31060d0b54aa987e5b546abb289cb>:0 \n  at Nowin.SaeaLayerCallback.IoCompleted (System.Object sender, System.Net.Sockets.SocketAsyncEventArgs e) [0x00049] in <6ac31060d0b54aa987e5b546abb289cb>:0 \n  at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted (System.Net.Sockets.SocketAsyncEventArgs e) [0x00014] in <affe4060066c42de8cdd6027cdb92b56>:0 \n  at System.Net.Sockets.SocketAsyncEventArgs.Complete () [0x00000] in <affe4060066c42de8cdd6027cdb92b56>:0 \n  at System.Net.Sockets.Socket.<ReceiveAsyncCallback>m__7 (System.IAsyncResult ares) [0x00068] in <affe4060066c42de8cdd6027cdb92b56>:0 \n  at System.Net.Sockets.SocketAsyncResult+<Complete>c__AnonStorey0.<>m__0 (System.Object _) [0x00000] in <affe4060066c42de8cdd6027cdb92b56>:0 \n  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00019] in <94fd79a3b7144c54b4cb162b50fc7761>:0 \n  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00096] in <94fd79a3b7144c54b4cb162b50fc7761>:0 \n  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <94fd79a3b7144c54b4cb162b50fc7761>:0 "